### PR TITLE
Update ligne-7.json : done VL7 Rilleux 2 carrefours

### DIFF
--- a/content/voies-cyclables/ligne-7.json
+++ b/content/voies-cyclables/ligne-7.json
@@ -508,7 +508,8 @@
       "properties": {
         "line": 7,
         "name": "Rillieux - Carrefour Avenue du 8 Mai",
-        "status": "wip",
+        "status": "done",
+        "doneAt": "28/08/2025",
         "type": "bidirectionnelle",
         "quality": "satisfactory",
         "link": "/voie-lyonnaise-7#route-du-mas-rillier-à-chemin-petit"
@@ -576,7 +577,8 @@
       "properties": {
         "line": 7,
         "name": "Carrefour Pierre Drevet",
-        "status": "wip",
+        "status": "done",
+        "doneAt": "28/08/2025",
         "type": "bidirectionnelle",
         "quality": "satisfactory",
         "link": "/voie-lyonnaise-7#route-du-mas-rillier-à-chemin-petit"


### PR DESCRIPTION
Mise à jour VL7 terminée sur Rilleux carrefours 8 mai 1945 et Pierre Drevet.