### PR TITLE
feat(counter): display arrondissement as subTitle

### DIFF
--- a/components/ContentFrame.vue
+++ b/components/ContentFrame.vue
@@ -90,13 +90,16 @@
     </div>
     <div class="relative px-4 sm:px-6 lg:px-8">
       <div class="text-lg max-w-prose mx-auto">
-        <span
+        <div
           v-if="header"
-          class="block text-base text-center text-lvv-blue-600 font-semibold tracking-wide uppercase"
-        >{{ header }}</span>
-        <h1 v-if="title" class="mt-2 block text-3xl text-center leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl">
+          class="text-base text-center text-lvv-blue-600 font-semibold tracking-wide uppercase"
+        >{{ header }}</div>
+        <h1 v-if="title" class="mt-2 text-3xl text-center leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl">
           {{ title }}
         </h1>
+        <h2 v-if="subTitle" class="text-2xl text-center leading-8 font-bold tracking-tight text-gray-500 sm:text-2xl">
+          {{ subTitle }}
+        </h2>
         <slot name="header" />
         <p class="mt-8 text-xl text-gray-500 leading-8 text-justify">
           {{ description }}
@@ -114,6 +117,7 @@
 defineProps({
   header: { type: String, required: false, default: undefined },
   title: { type: String, required: false, default: undefined },
+  subTitle: { type: String, required: false, default: undefined },
   description: { type: String, required: true },
   imageUrl: { type: String, required: false }
 });

--- a/pages/compteurs/comparaison/[slug].vue
+++ b/pages/compteurs/comparaison/[slug].vue
@@ -3,6 +3,7 @@
     v-if="veloCounter"
     header="Fréquentation vélo & voiture"
     :title="veloCounter.name"
+    :sub-title="veloCounter.arrondissement"
     description=""
   >
     <!-- <ClientOnly>

--- a/pages/compteurs/velo/[slug].vue
+++ b/pages/compteurs/velo/[slug].vue
@@ -3,6 +3,7 @@
     v-if="counter"
     header="compteur vélo"
     :title="counter.name"
+    :sub-title="counter.arrondissement"
     :description="counter.description"
     :image-url="counter.imageUrl"
   >

--- a/pages/compteurs/voiture/[slug].vue
+++ b/pages/compteurs/voiture/[slug].vue
@@ -3,6 +3,7 @@
     v-if="counter"
     header="compteur voiture"
     :title="counter.name"
+    :sub-title="counter.arrondissement"
     :description="counter.description"
     :image-url="counter.imageUrl"
   >


### PR DESCRIPTION
Salut

L'arrondissement ou la commune des compteurs vélo et voiture est affiché sur chaque card lorsqu'on est sur la grille qui les liste tous, mais bizarrement on avait omis d'indiquer cette mème information sur les pages individuelles.

Example:
<img width="1256" height="789" alt="image" src="https://github.com/user-attachments/assets/2b7c49f6-1a81-4401-b28b-cd849cd210f7" />
