### PR TITLE
fix: Ensure tooltip are not partially hidden when close to the edge of the screen

### DIFF
--- a/composables/useMap.ts
+++ b/composables/useMap.ts
@@ -764,9 +764,12 @@ export const useMap = () => {
     const clickedLayer = layers.find(layer => layer.isClicked());
     if (!clickedLayer) { return; }
 
+    const tooltipContentId = `${clickedLayer.id}-tooltip`;
     new Popup({ closeButton: false, closeOnClick: true })
       .setLngLat(clickEvent.lngLat)
-      .setHTML(`<div id="${clickedLayer.id}-tooltip-content"></div>`)
+      // set min dimensions so that the tooltip has some height/width before Vue mounts the component
+      // otherwise, if the popup is too close to the top of the map, it is not fully visible
+      .setHTML(`<div style="min-height: 500px; min-width: 100px" id="${tooltipContentId}"></div>`)
       .addTo(map);
 
     const props = clickedLayer.getTooltipProps();
@@ -778,7 +781,14 @@ export const useMap = () => {
           default: h(component, props),
           fallback: 'Chargement...'
         })
-      }).mount(`#${clickedLayer.id}-tooltip-content`);
+      }).mount(`#${tooltipContentId}`);
+
+      // reset dimensions set initially to position the popup in case the popup content ends up being smaller than the initial min dimensions
+      const tooltipContentEl = document.getElementById(tooltipContentId);
+      if (tooltipContentEl) {
+        tooltipContentEl.style.minHeight = 'initial';
+        tooltipContentEl.style.minWidth = 'initial';
+      }
     });
   }
 


### PR DESCRIPTION
Before

<img width="750" height="523" alt="image" src="https://github.com/user-attachments/assets/03d99ea8-0b7c-409f-933e-2a008767034d" />

After

<img width="750" height="523" alt="image" src="https://github.com/user-attachments/assets/156b22be-5569-4582-bb14-61a67b8d289f" />
