### PR TITLE
Update ligne-7.json WIP Belges - Tete d'Or

### DIFF
--- a/content/voies-cyclables/ligne-7.json
+++ b/content/voies-cyclables/ligne-7.json
@@ -1316,7 +1316,7 @@
       "properties": {
         "line": 7,
         "name": "Belges Tête d'Or",
-        "status": "planned",
+        "status": "wip",
         "type": "bidirectionnelle",
         "quality": "satisfactory",
         "link": "/voie-lyonnaise-7#boulevard-des-belges-quais-du-rhône-à-garibaldi"


### PR DESCRIPTION
Suite au début des travaux ce lundi sur la partie du boulevard des Belges au niveau de l'entrée du parc, je propose de passer ce tronçon de la VL7 de planned à WIP
WIP Belges Tete D'Or