### PR TITLE
fix: make sure map gets resized correctly

### DIFF
--- a/layouts/fullscreen.vue
+++ b/layouts/fullscreen.vue
@@ -6,8 +6,18 @@
 </template>
 
 <script setup>
-onBeforeMount(() => {
+import { useEventListener } from "@vueuse/core";
+
+const setVH = () => {
   document.documentElement.style.setProperty('--vh', window.innerHeight * 0.01 + 'px');
+};
+
+onBeforeMount(() => {
+  setVH();
+});
+
+useEventListener(window, 'resize', () => {
+  setVH();
 });
 
 </script>


### PR DESCRIPTION
C'est principalement pour éviter ce type de bug. 
(Je n'ai pas compris pourquoi il y a besoin de faire cette custom property par contre. Peut-être qu'on pourrait utiliser `dvh` à la place ?)

<img width="1454" height="1131" alt="image" src="https://github.com/user-attachments/assets/c2494bc3-a6e6-4b7e-b9cf-e302da5a6643" />
